### PR TITLE
fixed missing - in template

### DIFF
--- a/template/template.yaml
+++ b/template/template.yaml
@@ -387,7 +387,7 @@ Resources:
         -
           AttributeName: "ProductDescription"
           AttributeType: "S"
-
+        -
           AttributeName: "CreatedTime"
           AttributeType: "S"
       KeySchema:


### PR DESCRIPTION
*Issue #, if available:*
Hi, I submitted the cfn template to the aws designer tool and it crashed, I think its because around line 390 is missing a -

*Description of changes:*
Added the - and aws generator can draw the architecture diagram now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
