### PR TITLE
Remove unnecessary declaration of ProductDescription

### DIFF
--- a/template/template.yaml
+++ b/template/template.yaml
@@ -385,9 +385,6 @@ Resources:
           AttributeName: "ProductName"
           AttributeType: "S"
         -
-          AttributeName: "ProductDescription"
-          AttributeType: "S"
-        -
           AttributeName: "CreatedTime"
           AttributeType: "S"
       KeySchema:


### PR DESCRIPTION
Fixes: #6 
The declaration of the attribute `ProductDescription` generate an error during the creation of DynamoDB table:

```
One or more parameter values were invalid: Some AttributeDefinitions are not used. AttributeDefinitions: [ProductId, CreatedTime, ProductDescription, ProductName], keys used: [CreatedTime, ProductName, ProductId] (Service: AmazonDynamoDBv2; Status Code: 400; Error Code: ValidationException
```

The declaration of the attribute in also required in the `KeySchema`, but i don't think we want the description indexed, so i propose to remove the attribute declaration (it is successfully created by [the batch itself](https://github.com/aws-samples/aws-batch-processing-job-repo/blob/master/src/batch_processor.py#L28) during the `put_item()`).

See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-keyschema for reference on this CloudFormation constraint.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.