### PR TITLE
add flag to force building of amd64 docker image; busy-wait for stack…

### DIFF
--- a/exec.sh
+++ b/exec.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-STACK_NAME=fargate-batch-job
+export STACK_NAME=fargate-batch-job
 REGION=$(aws ec2 describe-availability-zones --output text --query 'AvailabilityZones[0].[RegionName]')
 ACCOUNT_NUMBER=$(aws sts get-caller-identity --query 'Account' --output text)
 
@@ -8,12 +8,16 @@ SOURCE_REPOSITORY=$PWD
 echo ' Creating CloudFormation Stack '
 aws cloudformation create-stack --stack-name $STACK_NAME --parameters ParameterKey=StackName,ParameterValue=$STACK_NAME --template-body file://template/template.yaml --capabilities CAPABILITY_NAMED_IAM
 
+while [ "$(aws cloudformation describe-stacks --stack-name $STACK_NAME --query 'Stacks[].StackStatus' --output text )" != 'CREATE_COMPLETE' ]
+  do
+    echo "Waiting on creation of $STACK_NAME"
+    sleep 60
+  done
+
 cd $SOURCE_REPOSITORY/src
 
-sleep 90s
-
 echo ' Updating the Amazon ECR with the code'
-docker build -t batch_processor .
+docker build  --platform=linux/amd64 -t batch_processor .
 docker tag batch_processor $(aws sts get-caller-identity --query 'Account' --output text).dkr.ecr.$REGION.amazonaws.com/$STACK_NAME-repository
 aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $(aws sts get-caller-identity --query 'Account' --output text).dkr.ecr.$REGION.amazonaws.com
 docker push $(aws sts get-caller-identity --query 'Account' --output text).dkr.ecr.$REGION.amazonaws.com/$STACK_NAME-repository


### PR DESCRIPTION
… create completion before continuing

Found your example repo useful, but since I'm on a Mac, default docker image built for Apple M1 ARM processor, leading to a cryptic error from 'exec' when the Batch job triggered. Also, build time on the stack was sufficient that the image failed to upload, saying that the repo was not available.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
