### PR TITLE
fix: typo on S3 policy

### DIFF
--- a/template/template.yaml
+++ b/template/template.yaml
@@ -238,7 +238,7 @@ Resources:
               Action:
                 - s3:PutObject
                 - s3:GetObject
-                - s3:ListBucket
+                - s3:ListBuckets
               Resource: 
                 - !Join
                   - ''


### PR DESCRIPTION
Small typo on template file,

s3:ListBucket

should be

s3:ListBuckets
